### PR TITLE
use pebble 2.8 (2.9 does not work with the current acme client) and add pebble-version to reusable workflow.

### DIFF
--- a/.github/actions/pebble/action.yml
+++ b/.github/actions/pebble/action.yml
@@ -3,7 +3,7 @@ description: "set up Pebble environment"
 inputs:
   pebble-version:
     description: "pebble version to set up"
-    default: "v2.9.0"
+    default: "v2.8.0"
   minica-version:
     description: "minica version to set up"
     default: "v1.1.0"

--- a/.github/workflows/go-test-multimod.yml
+++ b/.github/workflows/go-test-multimod.yml
@@ -26,6 +26,9 @@ on:
       with-pebble:
         type: boolean
         default: false
+      pebble-version:
+        type: string
+        default: "v2.8.0"
       with-chrome:
         type: boolean
         default: false
@@ -49,6 +52,8 @@ jobs:
       - uses: cloudengio/.github/.github/actions/go@main
       - if: ${{ inputs.with-webapp || inputs.with-pebble }}
         uses: cloudengio/.github/.github/actions/pebble@main
+        with:
+          pebble-version: ${{ inputs.pebble-version }}
       - if: ${{ inputs.with-webapp || inputs.with-chrome }}
         uses: cloudengio/.github/.github/actions/chrome@main
         id: setup-chrome


### PR DESCRIPTION
pebble 2.9 and the acme client in golang.org/x/crypto v0.46.0 seem to be incompatible, the go client creates a post request with an empty URL. 2.8 does not suffer from this problem so we pin to that version for now.
